### PR TITLE
Closing notifications w/o jQuery

### DIFF
--- a/notify.js
+++ b/notify.js
@@ -123,9 +123,9 @@
         this.myNotify.addEventListener('click', this, false);
     };
 
-    Notify.prototype.onShowNotification = function () {
+    Notify.prototype.onShowNotification = function (e) {
         if (this.onShowCallback) {
-            this.onShowCallback();
+            this.onShowCallback(e);
         }
     };
 


### PR DESCRIPTION
For those of us not using jQuery but trying to close a Notification after a timeout, there is a short and sweet way provided straight by the docs:
http://www.w3.org/TR/notifications/#close-steps
(HTML5 notifications expose an Event onShow)

``` js
notifyShow: function (event) {
  setTimeout(function() {
    event.currentTarget.cancel();
  }, 3000);
}
```

The only needed change in order for this to work is to simply add the Event as a param to the onShowNotification fn.
