### PR TITLE
Close the notification after destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Optional parameters
 * body: (string) - notification message body
 * icon: (string) - path for icon to display in notification
 * tag: (string) - unique identifier to stop duplicate notifications
+* timeout: (integer) - number of seconds to close the notification automatically
 * notifyShow: (function) - callback when notification is shown
 * notifyClose: (function) - callback when notification is closed
 * notifyClick: (function) - callback when notification is clicked

--- a/notify.js
+++ b/notify.js
@@ -111,6 +111,7 @@
 
 
     Notify.prototype.show = function () {
+        var that = this;
 
         if (!Notify.isSupported()) {
             return;
@@ -121,6 +122,12 @@
             'tag' : this.options.tag,
             'icon' : this.options.icon
         });
+
+        if (this.options.timeout && !isNaN(this.options.timeout)) {
+            setTimeout(function () {
+                that.myNotify.close();
+            }, this.options.timeout * 1000);
+        }
 
         this.myNotify.addEventListener('show', this, false);
         this.myNotify.addEventListener('error', this, false);


### PR DESCRIPTION
It's interesting to close/hide a desktop notification after destroy it to not be overflowed by them if you create a set of them. 
