### PR TITLE
Feedback for failed request (Chromium)

### DIFF
--- a/notify.js
+++ b/notify.js
@@ -95,8 +95,10 @@
 
     // asks the user for permission to display notifications.  Then calls the callback functions is supplied.
     Notify.requestPermission = function (onPermissionGrantedCallback, onPermissionDeniedCallback) {
+        var failed = true;
         if (Notify.isSupported()) {
             w.Notification.requestPermission(function (perm) {
+                failed = false;
                 switch (perm) {
                     case 'granted':
                         if (typeof onPermissionGrantedCallback === 'function') {
@@ -110,6 +112,9 @@
                         break;
                 }
             });
+            if(failed === true) {
+                throw new Error('Notify(): permission request failed.');
+            }
         }
     };
 


### PR DESCRIPTION
Currently no feedback is provided when permission request fails, e.g. when not bound to a click event in Chromium. To keep the platform independence up, it'd be helpful to provide feedback.
