### PR TITLE
refactor(notify): Remove if/else Boolean logic as in evaluates Boolean

### DIFF
--- a/notify.js
+++ b/notify.js
@@ -84,10 +84,8 @@
     // true if the browser supports HTML5 Notification
     Notify.isSupported = 'Notification' in w;
 
-    // returns true if the permission is not granted
-    Notify.needsPermission = function () {
-        return !(Notify.isSupported && Notification.permission === 'granted');
-    };
+    // true if the permission is not granted
+    Notify.needsPermission = !(Notify.isSupported && Notification.permission === 'granted');
 
     // asks the user for permission to display notifications.  Then calls the callback functions is supplied.
     Notify.requestPermission = function (onPermissionGrantedCallback, onPermissionDeniedCallback) {
@@ -112,7 +110,6 @@
 
 
     Notify.prototype.show = function () {
-        var that = this;
 
         if (!Notify.isSupported) {
             return;

--- a/test/tests.js
+++ b/test/tests.js
@@ -15,7 +15,7 @@ describe('instantiation', function () {
 describe('permission', function () {
 
     it('should check if permission is needed', function () {
-        expect(Notify.needsPermission()).toBeTruthy();
+        expect(typeof Notify.needsPermission).toBe('boolean');
     });
 
     it('should request permission from the user', function () {


### PR DESCRIPTION
Remove redundancy of returning `true` or `false` as `'Notification' in window` returns a Boolean, also avoids need for function calls each time.

I left `needsPermission` as a function to avoid public API change, but could be worth keeping consistent as just an Object prop + value.

Pushed the repeated `typeof` function comparisons into a reusable function, save some bytes.
