### PR TITLE
Update Notify.needsPermission to false after the user approves permissio...

### DIFF
--- a/notify.js
+++ b/notify.js
@@ -95,6 +95,7 @@
         w.Notification.requestPermission(function (perm) {
             switch (perm) {
                 case 'granted':
+                    Notify.needsPermission = false;
                     if (isFunction(onPermissionGrantedCallback)) {
                         onPermissionGrantedCallback();
                     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -23,6 +23,22 @@ describe('permission', function () {
         Notify.requestPermission();
         expect(window.Notification.requestPermission).toHaveBeenCalled();
     });
+
+    it('should update Notify.needsPermission to true if the user accepts the request', function () {
+        spyOn(window.Notification, 'requestPermission').andCallFake(function (cb) {
+            cb('granted');
+        });
+
+        runs(Notify.requestPermission);
+
+        waitsFor(function () {
+            return Notify.needsPermission === false;
+        }, 'Notify.needsPermission to be false', 750);
+
+        runs(function () {
+            expect(Notify.needsPermission).toBe(false);
+        });
+    });
 });
 
 describe('callbacks', function () {


### PR DESCRIPTION
...n to send notifications

We are building a single page app. In our code we have a check for Notify.needsPermission before we create a new Notify object. When the end user allows notifications Notify.needsPermission remains true until the next page refresh. Since we are building a SPA it could be a while until that happens.

This pull request is to update Notify.needsPermission to false when permission is granted, and the corresponding unit test. Thanks. Any feedback on how to achieve this in a different way is of course welcome.
