### PR TITLE
Update notify.js

### DIFF
--- a/notify.js
+++ b/notify.js
@@ -48,7 +48,7 @@
 
         this.permission = null;
 
-        if (!Notify.isSupported) {
+        if (!Notify.isSupported()) {
             return;
         }
 


### PR DESCRIPTION
isSupported is now a function() rather than a boolean.

given the problem with ghost notifications, it's probably better to determine this once?