### PR TITLE
Document show and close methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ Static methods and properties
 * `Notify.isSupported` - Function to test for Web Notifications API browser support
 * `Notify.needsPermission` - Boolean property to check if permission is needed for the user to receive notifications.
 
+Instance methods
+-----------------------------
+* `Notify.show` - Function to display the Notify instance
+* `Notify.close` - Function to close the Notify instance
+
 Testing
 -------
 


### PR DESCRIPTION
I needed to find if there was a `close` method I could use. There was, however this was not documented. 

If you decide to document `close`, I thought it would also be useful to document `show`.