### PR TITLE
Support `silent` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Optional parameters
 * `tag`: (string) - unique identifier to stop duplicate notifications
 * `lang`: (string) - BCP 47 language tag for the notification (default: `en`)
 * `timeout`: (integer) - number of seconds to close the notification automatically
+* `silent`: (boolean) - indicates that no sounds or vibrations should be made (default: `false`)
 * `requireInteraction`: (boolean) - keep the notification open indefinitely
 * `closeOnClick`: (boolean) - close the notification when clicked. Useful in chrome where the notification remains open until the timeout or the x is clicked.
 * `notifyShow`: (function) - callback when notification is shown

--- a/notify.js
+++ b/notify.js
@@ -47,7 +47,8 @@
             notifyError: null,
             timeout: null,
             requireInteraction: false,
-            closeOnClick: false
+            closeOnClick: false,
+            silent: false
         };
 
         this.permission = null;
@@ -136,6 +137,7 @@
             'icon': this.options.icon,
             'lang': this.options.lang,
             'requireInteraction': this.options.requireInteraction,
+            'silent': this.options.silent,
             'closeOnClick': this.options.closeOnClick
         });
 


### PR DESCRIPTION
According to [the spec](https://notifications.spec.whatwg.org/#notifications):

> A notification has an associated silent preference flag which is initially unset. When set indicates that no sounds or vibrations should be made.

And it [has a boolean `false` for default value](https://notifications.spec.whatwg.org/#dom-notificationoptions-silent):

```
dictionary NotificationOptions {
  ...
  boolean silent = false;
  ...
};
```

Chrome v43 and Electron v0.36.5 already support this option: https://developer.mozilla.org/en-US/docs/Web/API/notification/silent , https://github.com/atom/electron/releases/tag/v0.36.5 .

We're using Notify.js with Electron v0.36.5 for our desktop and web apps, and found an issue that relative to this new `silent` option:

- Use Notify.js to handle all notifications
- Use `notifyShow` callback for playing custom sound
- When notification shows, Electron will play sound twice: one is the system's default sound, one is the custom sound.
