### PR TITLE
Add serviceWorker option

### DIFF
--- a/src/notify.js
+++ b/src/notify.js
@@ -5,6 +5,20 @@
  */
 
 const N = window.Notification;
+const defaultOptions = {
+    icon: '',
+    body: '',
+    tag: '',
+    lang: 'en',
+    notifyShow: null,
+    notifyClose: null,
+    notifyClick: null,
+    notifyError: null,
+    timeout: null,
+    requireInteraction: false,
+    closeOnClick: false,
+    silent: false
+};
 
 function isFunction(item) {
     return typeof item === 'function';
@@ -17,29 +31,14 @@ function Notify(title, options) {
     }
 
     this.title = title;
-    this.options = {
-        icon: '',
-        body: '',
-        tag: '',
-        lang: 'en',
-        notifyShow: null,
-        notifyClose: null,
-        notifyClick: null,
-        notifyError: null,
-        timeout: null,
-        requireInteraction: false,
-        closeOnClick: false,
-        silent: false
-    };
     this.permission = null;
 
     //User defined options for notification content
     if (typeof options === 'object') {
-        for (let i in options) {
-            if(options.hasOwnProperty(i)) {
-                this.options[i] = options[i];
-            }
-        }
+        this.options = {
+            ...defaultOptions,
+            ...options
+        };
 
         //callback when notification is displayed
         if (isFunction(this.options.notifyShow)) {


### PR DESCRIPTION
This is a rather naive implementation of the API I proposed in #56. For now the event handlers

```javascript
this.myNotify.addEventListener('show', this, false);
this.myNotify.addEventListener('error', this, false);
this.myNotify.addEventListener('close', this, false);
this.myNotify.addEventListener('click', this, false);
```

don't work. Also, https://github.com/alexgibson/notify.js/compare/master...perrin4869:master#diff-bd33361ada7e8d2d2fefd6aa1b7a6061R167 should probably be improved.

Other than that, it works just fine. Please test this and give me your feedback :)