### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,6 @@
         "package.json",
         "rollup.config.js"
         "src",
-        "test",
+        "test"
     ]
 }


### PR DESCRIPTION
Trailing comma was causing a EMALFORMED error in Bower.