### PR TITLE
Remove useless error thrown

### DIFF
--- a/dist/notify.js
+++ b/dist/notify.js
@@ -129,7 +129,7 @@ Notify.isSupported = function (perm) {
     }
 
     if (perm === 'granted' || N.permission === 'granted') {
-        throw new Error('You must only call this before calling Notification.requestPermission(), otherwise this feature detect would trigger an actual notification!');
+        return true;
     }
 
     try {
@@ -142,21 +142,27 @@ Notify.isSupported = function (perm) {
     return true;
 };
 
-// true if the permission is not granted
-Notify.needsPermission = N && N.permission && N.permission === 'granted' ? false : true;
+// define Notify.needsPermission : true if the permission is not granted
+if (N && N.permission) {
+    Object.defineProperty(Notify, 'needsPermission', {
+        get: function get$$1() {
+            return N.permission === 'granted' ? false : true;
+        }
+    });
+} else {
+    Notify.needsPermission = true;
+}
 
 // asks the user for permission to display notifications.  Then calls the callback functions is supplied.
 Notify.requestPermission = function (onPermissionGrantedCallback, onPermissionDeniedCallback) {
     N.requestPermission(function (perm) {
         switch (perm) {
             case 'granted':
-                Notify.needsPermission = false;
                 if (isFunction(onPermissionGrantedCallback)) {
                     onPermissionGrantedCallback();
                 }
                 break;
             case 'denied':
-                Notify.needsPermission = true;
                 if (isFunction(onPermissionDeniedCallback)) {
                     onPermissionDeniedCallback();
                 }

--- a/src/notify.js
+++ b/src/notify.js
@@ -81,21 +81,27 @@ Notify.isSupported = function(perm) {
     return true;
 };
 
-// true if the permission is not granted
-Notify.needsPermission = (N && N.permission && N.permission === 'granted') ? false : true;
+// define Notify.needsPermission : true if the permission is not granted
+if (N && N.permission) {
+    Object.defineProperty(Notify, 'needsPermission', {
+        get() {
+            return N.permission === 'granted' ? false : true;
+        }
+    });
+} else {
+    Notify.needsPermission = true;
+}
 
 // asks the user for permission to display notifications.  Then calls the callback functions is supplied.
 Notify.requestPermission = function(onPermissionGrantedCallback, onPermissionDeniedCallback) {
     N.requestPermission(function(perm) {
         switch (perm) {
         case 'granted':
-            Notify.needsPermission = false;
             if (isFunction(onPermissionGrantedCallback)) {
                 onPermissionGrantedCallback();
             }
             break;
         case 'denied':
-            Notify.needsPermission = true;
             if (isFunction(onPermissionDeniedCallback)) {
                 onPermissionDeniedCallback();
             }

--- a/src/notify.js
+++ b/src/notify.js
@@ -68,7 +68,7 @@ Notify.isSupported = function(perm) {
     }
 
     if (perm === 'granted' || N.permission === 'granted') {
-        throw new Error('You must only call this before calling Notification.requestPermission(), otherwise this feature detect would trigger an actual notification!');
+        return true;
     }
 
     try {

--- a/test/tests.js
+++ b/test/tests.js
@@ -52,6 +52,7 @@ describe('permission', function() {
     describe('requestPermission (granted)', function() {
         beforeEach(function(done) {
             spyOn(window.Notification, 'requestPermission').and.callFake(function(cb) {
+                Object.defineProperty(window.Notification, 'permission', { get() { return 'granted'; } });
                 cb('granted');
                 done();
             });
@@ -66,6 +67,7 @@ describe('permission', function() {
     describe('requestPermission (denied)', function() {
         beforeEach(function(done) {
             spyOn(window.Notification, 'requestPermission').and.callFake(function(cb) {
+                Object.defineProperty(window.Notification, 'permission', { get() { return 'denied'; } });
                 cb('denied');
                 done();
             });

--- a/test/tests.js
+++ b/test/tests.js
@@ -24,10 +24,10 @@ describe('isSupported', function() {
         expect(Notify.isSupported()).toBeTruthy();
     });
 
-    it('should throw an error if permission has already been granted', function() {
+    it('should return true when permission has already been granted', function() {
         expect(function() {
             Notify.isSupported('granted');
-        }).toThrow();
+        }).toBeTruthy();
     });
 });
 


### PR DESCRIPTION
Knock Knock :door: anybody still here ? :smile:

I noticed an error in our logs : `You must only call this before calling Notification.requestPermission(), otherwise this feature detect would trigger an actual notification!` and I know why it happens.

**The problem :**

Imagine a scenario where a user opens up a web chat app in two different browser tab. At some point the user receives a chat message and the app ask for permission to display web notifications. Since the app is realtime, it will ask for permission in BOTH tabs at the same time. The user may then click "allow" in the current tab and leave the other untouched.

At this point, `Notify.needsPermission` will still be `true` in the other tab even if `N.permission === 'granted'`, which will then lead us to calling `Notify.isSupported()` and triggering the error in the other tab when a new message is received.

**The fix :**

I think it's safe to assume that if the permission has been granted already, this feature MUST be supported ! Therefore we can just return `true` there, instead of throwing and error.

In fact, to completely fix this scenario we would need to refactor `Notify.needsPermission` into a method/getter that checks if `N.permission === 'granted'` equals true instead of a boolean initialized on start :man_shrugging: 